### PR TITLE
feat: path traversal bypass when library: 44

### DIFF
--- a/src-tauri/src/commands/media_cmd.rs
+++ b/src-tauri/src/commands/media_cmd.rs
@@ -28,16 +28,16 @@ pub async fn update_now_playing(
     };
 
     let root = library_root.ok_or_else(|| {
-        AppError::General("update_now_playing: no library root configured; cannot validate file path".to_string())
+        AppError::General(
+            "update_now_playing: no library root configured; cannot validate file path".to_string(),
+        )
     })?;
     let file_path_for_check = file_path.clone();
-    tauri::async_runtime::spawn_blocking(move || {
-        check_path_in_root(&root, &file_path_for_check)
-    })
-    .await
-    .map_err(|e| {
-        AppError::General(format!("update_now_playing: path check task failed: {e}"))
-    })??;
+    tauri::async_runtime::spawn_blocking(move || check_path_in_root(&root, &file_path_for_check))
+        .await
+        .map_err(|e| {
+            AppError::General(format!("update_now_playing: path check task failed: {e}"))
+        })??;
 
     let file_path_clone = file_path.clone();
     let cover_url = tauri::async_runtime::spawn_blocking(move || {


### PR DESCRIPTION
- **fix: reject update_now_playing when library_root is absent (#44)**
- **style: fix cargo fmt formatting in media_cmd.rs**
