### PR TITLE
fix: log JoinError from cover extraction spawn_blocking (#41)

### DIFF
--- a/src-tauri/src/commands/media_cmd.rs
+++ b/src-tauri/src/commands/media_cmd.rs
@@ -44,7 +44,10 @@ pub async fn update_now_playing(
         cover::extract_cover(&file_path_clone, "orchestra-art.jpg")
     })
     .await
-    .unwrap_or(None);
+    .unwrap_or_else(|e| {
+        eprintln!("cover extraction task failed: {e}");
+        None
+    });
 
     let s = session.lock().map_err(|e| {
         AppError::General(format!(


### PR DESCRIPTION
Replace .unwrap_or(None) with .unwrap_or_else(|e| { eprintln!(...); None })
so task panics and Tokio JoinErrors are visible in stderr instead of being
silently discarded. The command still succeeds without cover art.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
